### PR TITLE
게시판 검색 구현

### DIFF
--- a/src/main/java/com/example/projectboard/controller/ArticleController.java
+++ b/src/main/java/com/example/projectboard/controller/ArticleController.java
@@ -39,6 +39,7 @@ public class ArticleController {
         List<Integer> barNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(), articles.getTotalPages());
         map.addAttribute("articles", articles);
         map.addAttribute("paginationBarNumbers", barNumbers);
+        map.addAttribute("searchTypes", SearchType.values());
         map.addAttribute("hashtags", articleService.getAllHashTag()); //hashtag 목록
 
         return "articles/index";

--- a/src/main/java/com/example/projectboard/controller/ArticleController.java
+++ b/src/main/java/com/example/projectboard/controller/ArticleController.java
@@ -32,10 +32,11 @@ public class ArticleController {
     public String articles(
             @RequestParam(required = false) SearchType searchType,
             @RequestParam(required = false) String searchValue,
+            @RequestParam(required = false) List<String> filterTags,
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
             ModelMap map
     ) {
-        Page<ArticleResponse> articles = articleService.searchArticles(searchType, searchValue, pageable).map(ArticleResponse::from);
+        Page<ArticleResponse> articles = articleService.searchArticles(searchType, searchValue, filterTags, pageable).map(ArticleResponse::from);
         List<Integer> barNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(), articles.getTotalPages());
         map.addAttribute("articles", articles);
         map.addAttribute("paginationBarNumbers", barNumbers);

--- a/src/main/java/com/example/projectboard/domain/type/SearchType.java
+++ b/src/main/java/com/example/projectboard/domain/type/SearchType.java
@@ -1,5 +1,17 @@
 package com.example.projectboard.domain.type;
 
+import lombok.Getter;
+
 public enum SearchType {
-    TITLE, CONTENT, ID, NICKNAME, HASHTAG;
+    TITLE("제목"),
+    CONTENT("본문"),
+    HASHTAG("해시태그"),
+    NICKNAME("작성자");
+
+    @Getter
+    private final String description;
+
+    SearchType(String description) {
+        this.description = description;
+    }
 }

--- a/src/main/java/com/example/projectboard/domain/type/SearchType.java
+++ b/src/main/java/com/example/projectboard/domain/type/SearchType.java
@@ -5,7 +5,6 @@ import lombok.Getter;
 public enum SearchType {
     TITLE("제목"),
     CONTENT("본문"),
-    HASHTAG("해시태그"),
     NICKNAME("작성자");
 
     @Getter

--- a/src/main/java/com/example/projectboard/repository/ArticleRepository.java
+++ b/src/main/java/com/example/projectboard/repository/ArticleRepository.java
@@ -20,13 +20,18 @@ public interface ArticleRepository extends
         , QuerydslPredicateExecutor<Article>
         , QuerydslBinderCustomizer<QArticle> {
 
+
     Page<Article> findByTitleContaining(String title, Pageable pageable);
     Page<Article> findByContentContaining(String content, Pageable pageable);
-    Page<Article> findByHashTag(String hashTag, Pageable pageable);
-    Page<Article> findByMember_UserIdContaining(String userId, Pageable pageable);
     Page<Article> findByMember_NickNameContaining(String nickName, Pageable pageable);
 
-    @Query(value = "select distinct a.hashTag from Article a")
+    Page<Article> findByTitleContainingAndHashTagIn(String title, List<String> filterTags, Pageable pageable);
+    Page<Article> findByContentContainingAndHashTagIn(String content, List<String> filterTags, Pageable pageable);
+    Page<Article> findByMember_NickNameContainingAndHashTagIn(String nickName, List<String> filterTags, Pageable pageable);
+
+    Page<Article> findByHashTagIn(List<String> filterTags, Pageable pageable);
+
+    @Query(value = "select distinct a.hashTag from Article a where a.hashTag is not null")
     public List<String> findAllHashTag();
 
 

--- a/src/main/java/com/example/projectboard/service/ArticleService.java
+++ b/src/main/java/com/example/projectboard/service/ArticleService.java
@@ -32,8 +32,7 @@ public class ArticleService {
         return switch (searchType) {
             case TITLE -> articleRepository.findByTitleContaining(searchKeyword, pageable).map(ArticleDto::from);
             case CONTENT -> articleRepository.findByContentContaining(searchKeyword, pageable).map(ArticleDto::from);
-            case HASHTAG -> articleRepository.findByHashTag(searchKeyword, pageable).map(ArticleDto::from);
-            case ID -> articleRepository.findByMember_UserIdContaining(searchKeyword, pageable).map(ArticleDto::from);
+            case HASHTAG -> articleRepository.findByHashTag("#" + searchKeyword, pageable).map(ArticleDto::from);
             case NICKNAME -> articleRepository.findByMember_NickNameContaining(searchKeyword, pageable).map(ArticleDto::from);
         };
     }

--- a/src/main/java/com/example/projectboard/service/ArticleService.java
+++ b/src/main/java/com/example/projectboard/service/ArticleService.java
@@ -24,17 +24,31 @@ public class ArticleService {
     private final ArticleRepository articleRepository;
 
     @Transactional(readOnly = true)
-    public Page<ArticleDto> searchArticles(SearchType searchType, String searchKeyword, Pageable pageable) {
-        if (searchKeyword == null || searchKeyword.isBlank()) {
+    public Page<ArticleDto> searchArticles(SearchType searchType, String searchKeyword, List<String> filterTags, Pageable pageable) {
+        if ((searchKeyword == null || searchKeyword.isBlank()) && (filterTags == null || filterTags.isEmpty())) {
             return articleRepository.findAll(pageable).map(ArticleDto::from);
         }
 
-        return switch (searchType) {
-            case TITLE -> articleRepository.findByTitleContaining(searchKeyword, pageable).map(ArticleDto::from);
-            case CONTENT -> articleRepository.findByContentContaining(searchKeyword, pageable).map(ArticleDto::from);
-            case HASHTAG -> articleRepository.findByHashTag("#" + searchKeyword, pageable).map(ArticleDto::from);
-            case NICKNAME -> articleRepository.findByMember_NickNameContaining(searchKeyword, pageable).map(ArticleDto::from);
-        };
+        if (searchKeyword == null || searchKeyword.isBlank()) {
+            //필터링 조회
+            return articleRepository.findByHashTagIn(filterTags, pageable).map(ArticleDto::from);
+        }
+
+        if (filterTags == null || filterTags.isEmpty()) {
+            //검색바 조회
+            return switch (searchType) {
+                case TITLE -> articleRepository.findByTitleContaining(searchKeyword, pageable).map(ArticleDto::from);
+                case CONTENT -> articleRepository.findByContentContaining(searchKeyword, pageable).map(ArticleDto::from);
+                case NICKNAME -> articleRepository.findByMember_NickNameContaining(searchKeyword, pageable).map(ArticleDto::from);
+            };
+        } else {
+            //검색바 + 필터링 조회
+            return switch (searchType) {
+                case TITLE -> articleRepository.findByTitleContainingAndHashTagIn(searchKeyword, filterTags, pageable).map(ArticleDto::from);
+                case CONTENT -> articleRepository.findByContentContainingAndHashTagIn(searchKeyword, filterTags, pageable).map(ArticleDto::from);
+                case NICKNAME -> articleRepository.findByMember_NickNameContainingAndHashTagIn(searchKeyword, filterTags, pageable).map(ArticleDto::from);
+            };
+        }
     }
 
     @Transactional(readOnly = true)

--- a/src/main/resources/templates/articles/index.html
+++ b/src/main/resources/templates/articles/index.html
@@ -32,29 +32,12 @@
                                 <h2 class="grid-title"><i class="fa fa-filter"></i> Filters</h2>
                                 <hr>
 
-                                <!-- BEGIN FILTER BY CATEGORY -->
-                                <h4>By hashtag:</h4>
+                                <!-- BEGIN FILTER BY HASHTAG -->
+                                <h4>By tag:</h4>
                                 <div class="checkbox" id="hash-tag">
                                     <input type="checkbox" class="icheck" />
                                 </div>
-                                <!-- END FILTER BY CATEGORY -->
-
-                                <div class="padding"><br></div>
-
-                                <!-- BEGIN FILTER BY DATE -->
-                                <h4>By date:</h4>
-                                From
-                                <div class="input-group date form_date">
-                                    <input type="date" data-link-field="dtp-input1" data-date-format="yyyy-mm-dd" class="form-control">
-                                </div>
-                                <input type="hidden" id="dtp_input1" value="">
-
-                                To
-                                <div class="input-group date form_date">
-                                    <input type="date" data-link-field="dtp-input2" data-date-format="yyyy-mm-dd" class="form-control">
-                                </div>
-                                <input type="hidden" id="dtp_input2" value="">
-                                <!-- END FILTER BY DATE -->
+                                <!-- END FILTER BY HASHTAG -->
                             </div>
                             <!-- END FILTERS -->
                             <!-- BEGIN RESULT -->
@@ -76,10 +59,10 @@
                                         </thead>
                                         <tbody>
                                         <tr>
-                                            <td class="title">첫 번째 글</td>
-                                            <td class="hash-tag">#spring</td>
-                                            <td class="nick-name">pyo</td>
-                                            <td class="created-at">2022-12-22</td>
+                                            <td class="title col-6 text-truncate" style="max-width: 400px">첫 번째 글</td>
+                                            <td class="hash-tag col">#spring</td>
+                                            <td class="nick-name col">pyo</td>
+                                            <td class="created-at col">2022-12-22</td>
                                         </tr>
                                         <tr>
                                             <td>두 번째 글</td>
@@ -101,12 +84,14 @@
                                 <!-- BEGIN SEARCH INPUT -->
                                 <form action="/articles" method="get">
                                     <div class="row search-group">
+                                        <input id="search-value-sort" type="hidden" name="sort"/>
                                         <select id="search-type" name="searchType" class="form-control">
                                             <option>제목</option>
                                             <option>본문</option>
                                             <option>작성자</option>
                                         </select>
                                         <input id="search-value" type="text" name="searchValue" class="form-control" value=""/>
+                                        <input id="search-value-filter-tags" type="hidden" name="filterTags"/>
                                         <button class="btn btn-primary" type="submit">
                                             <i class="fa fa-search"></i>
                                         </button>

--- a/src/main/resources/templates/articles/index.html
+++ b/src/main/resources/templates/articles/index.html
@@ -33,7 +33,7 @@
                                 <hr>
 
                                 <!-- BEGIN FILTER BY CATEGORY -->
-                                <h4>By category:</h4>
+                                <h4>By hashtag:</h4>
                                 <div class="checkbox" id="hash-tag">
                                     <input type="checkbox" class="icheck" />
                                 </div>
@@ -59,7 +59,7 @@
                             <!-- END FILTERS -->
                             <!-- BEGIN RESULT -->
                             <div class="col-md-9">
-                                <h2><i class="fa fa-file-o"></i> Result</h2>
+                                <h2><i class="fa fa-file-o"></i> Articles</h2>
                                 <hr>
                                 <div class="padding"></div>
 
@@ -99,17 +99,19 @@
                                 <!-- END TABLE RESULT -->
 
                                 <!-- BEGIN SEARCH INPUT -->
-                                <div class="row search-group">
-                                    <select id="sel" class="form-control">
-                                        <option>제목</option>
-                                        <option>본문</option>
-                                        <option>작성자</option>
-                                    </select>
-                                    <input type="text" class="form-control" value="">
-                                    <button class="btn btn-primary" type="button">
-                                        <i class="fa fa-search"></i>
-                                    </button>
-                                </div>
+                                <form action="/articles" method="get">
+                                    <div class="row search-group">
+                                        <select id="search-type" name="searchType" class="form-control">
+                                            <option>제목</option>
+                                            <option>본문</option>
+                                            <option>작성자</option>
+                                        </select>
+                                        <input id="search-value" type="text" name="searchValue" class="form-control" value=""/>
+                                        <button class="btn btn-primary" type="submit">
+                                            <i class="fa fa-search"></i>
+                                        </button>
+                                    </div>
+                                </form>
                                 <!-- END SEARCH INPUT -->
 
                                 <!-- BEGIN PAGINATION -->

--- a/src/main/resources/templates/articles/index.th.xml
+++ b/src/main/resources/templates/articles/index.th.xml
@@ -4,7 +4,14 @@
     <attr sel="#footer" th:replace="footer :: footer"/>
 
     <attr sel="#hash-tag" th:each="hashtag : ${hashtags}">
-        <attr sel="input" th:text="' ' + ${hashtag}"/>
+        <attr sel="input" th:text="' ' + ${hashtag}" th:value="${hashtag}"
+              th:checked="${param.filterTags == null ? 'false' : #strings.contains(param.filterTags, '' + hashtag)}"
+              th:onclick="|location.href='@{/articles(
+                  sort=${param.sort},
+                  searchType=${param.searchType},
+                  searchValue=${param.searchValue},
+                  filterTags=${param.filterTags == null ? '' + hashtag : #strings.contains(param.filterTags, '' + hashtag) ? #strings.replace(param.filterTags, ',' + hashtag, '').replace('' + hashtag, '') : #strings.append(param.filterTags, (#strings.isEmpty(param.filterTags) ? '' : ',') + hashtag)}
+              )}'|"/>
     </attr>
 
     <attr sel="#article-table">
@@ -14,28 +21,32 @@
                       page=${articles.number},
                       sort='title' + (${articles.sort.getOrderFor('title')} != null ? (${articles.sort.getOrderFor('title').direction.name} != 'DESC' ? ',desc' : '') : ''),
                       searchType=${param.searchType},
-                      searchValue=${param.searchValue}
+                      searchValue=${param.searchValue},
+                      filterTags=${param.filterTags}
                   )}'|"/>
             <attr sel="th.hash-tag" th:text="'태그'"
                   th:onclick="|location.href='@{/articles(
                       page=${articles.number},
                       sort='hashTag' + (${articles.sort.getOrderFor('hashTag')} != null ? (${articles.sort.getOrderFor('hashTag').direction.name} != 'DESC' ? ',desc' : '') : ''),
                       searchType=${param.searchType},
-                      searchValue=${param.searchValue}
+                      searchValue=${param.searchValue},
+                      filterTags=${param.filterTags}
                   )}'|"/>
             <attr sel="th.nick-name" th:text="'작성자'"
                   th:onclick="|location.href='@{/articles(
                       page=${articles.number},
                       sort='member.nickName' + (${articles.sort.getOrderFor('member.nickName')} != null ? (${articles.sort.getOrderFor('member.nickName').direction.name} != 'DESC' ? ',desc' : '') : ''),
                       searchType=${param.searchType},
-                      searchValue=${param.searchValue}
+                      searchValue=${param.searchValue},
+                      filterTags=${param.filterTags}
                   )}'|"/>
             <attr sel="th.created-at" th:text="'작성일'"
                   th:onclick="|location.href='@{/articles(
                       page=${articles.number},
                       sort='createdAt' + (${articles.sort.getOrderFor('createdAt')} != null ? (${articles.sort.getOrderFor('createdAt').direction.name} != 'DESC' ? ',desc' : '') : ''),
                       searchType=${param.searchType},
-                      searchValue=${param.searchValue}
+                      searchValue=${param.searchValue},
+                      filterTags=${param.filterTags}
                   )}'|"/>
         </attr>
 
@@ -61,6 +72,9 @@
 
     <attr sel="#search-value" th:value="${param.searchValue}"/>
 
+    <attr sel="#search-value-sort" th:value="${param.sort}"/>
+    <attr sel="#search-value-filter-tags" th:value="${param.filterTags}"/>
+
     <attr sel="#pagination">
         <attr sel="ul">
             <attr sel="li[0]" th:class="'page-item' + (${articles.number} <= 0 ? ' disabled' : '')">
@@ -70,7 +84,8 @@
                             page=${0},
                             sort=${param.sort},
                             searchType=${param.searchType},
-                            searchValue=${param.searchValue}
+                            searchValue=${param.searchValue},
+                            filterTags=${param.filterTags}
                       )}"
                 />
             </attr>
@@ -81,7 +96,8 @@
                             page=${articles.number - 1},
                             sort=${param.sort},
                             searchType=${param.searchType},
-                            searchValue=${param.searchValue}
+                            searchValue=${param.searchValue},
+                            filterTags=${param.filterTags}
                       )}"
                 />
             </attr>
@@ -92,7 +108,8 @@
                             page=${pageNumber},
                             sort=${param.sort},
                             searchType=${param.searchType},
-                            searchValue=${param.searchValue}
+                            searchValue=${param.searchValue},
+                            filterTags=${param.filterTags}
                       )}"
                 />
             </attr>
@@ -104,7 +121,8 @@
                             page=${articles.number + 1},
                             sort=${param.sort},
                             searchType=${param.searchType},
-                            searchValue=${param.searchValue}
+                            searchValue=${param.searchValue},
+                            filterTags=${param.filterTags}
                       )}"
                 />
             </attr>
@@ -116,7 +134,8 @@
                             page=${articles.totalPages - 1},
                             sort=${param.sort},
                             searchType=${param.searchType},
-                            searchValue=${param.searchValue}
+                            searchValue=${param.searchValue},
+                            filterTags=${param.filterTags}
                       )}"
                 />
             </attr>

--- a/src/main/resources/templates/articles/index.th.xml
+++ b/src/main/resources/templates/articles/index.th.xml
@@ -12,22 +12,30 @@
             <attr sel="th.title" th:text="'제목'"
                   th:onclick="|location.href='@{/articles(
                       page=${articles.number},
-                      sort='title' + (${articles.sort.getOrderFor('title')} != null ? (${articles.sort.getOrderFor('title').direction.name} != 'DESC' ? ',desc' : '') : '')
+                      sort='title' + (${articles.sort.getOrderFor('title')} != null ? (${articles.sort.getOrderFor('title').direction.name} != 'DESC' ? ',desc' : '') : ''),
+                      searchType=${param.searchType},
+                      searchValue=${param.searchValue}
                   )}'|"/>
             <attr sel="th.hash-tag" th:text="'태그'"
                   th:onclick="|location.href='@{/articles(
                       page=${articles.number},
-                      sort='hashTag' + (${articles.sort.getOrderFor('hashTag')} != null ? (${articles.sort.getOrderFor('hashTag').direction.name} != 'DESC' ? ',desc' : '') : '')
+                      sort='hashTag' + (${articles.sort.getOrderFor('hashTag')} != null ? (${articles.sort.getOrderFor('hashTag').direction.name} != 'DESC' ? ',desc' : '') : ''),
+                      searchType=${param.searchType},
+                      searchValue=${param.searchValue}
                   )}'|"/>
             <attr sel="th.nick-name" th:text="'작성자'"
                   th:onclick="|location.href='@{/articles(
                       page=${articles.number},
-                      sort='member.nickName' + (${articles.sort.getOrderFor('member.nickName')} != null ? (${articles.sort.getOrderFor('member.nickName').direction.name} != 'DESC' ? ',desc' : '') : '')
+                      sort='member.nickName' + (${articles.sort.getOrderFor('member.nickName')} != null ? (${articles.sort.getOrderFor('member.nickName').direction.name} != 'DESC' ? ',desc' : '') : ''),
+                      searchType=${param.searchType},
+                      searchValue=${param.searchValue}
                   )}'|"/>
             <attr sel="th.created-at" th:text="'작성일'"
                   th:onclick="|location.href='@{/articles(
                       page=${articles.number},
-                      sort='createdAt' + (${articles.sort.getOrderFor('createdAt')} != null ? (${articles.sort.getOrderFor('createdAt').direction.name} != 'DESC' ? ',desc' : '') : '')
+                      sort='createdAt' + (${articles.sort.getOrderFor('createdAt')} != null ? (${articles.sort.getOrderFor('createdAt').direction.name} != 'DESC' ? ',desc' : '') : ''),
+                      searchType=${param.searchType},
+                      searchValue=${param.searchValue}
                   )}'|"/>
         </attr>
 
@@ -42,29 +50,75 @@
         </attr>
     </attr>
 
+    <attr sel="#search-type" th:remove="all-but-first">
+        <attr sel="option[0]"
+              th:each="searchType : ${searchTypes}"
+              th:value="${searchType.name}"
+              th:text="${searchType.description}"
+              th:selected="${param.searchType != null && (param.searchType.toString == searchType.name)}"
+        />
+    </attr>
+
+    <attr sel="#search-value" th:value="${param.searchValue}"/>
+
     <attr sel="#pagination">
         <attr sel="ul">
             <attr sel="li[0]" th:class="'page-item' + (${articles.number} <= 0 ? ' disabled' : '')">
-                <attr sel="a" th:text="'«'" th:href="@{/articles(page=${0})}"
-                      th:class="'page-link' + (${articles.number} <= 0 ? ' disabled' : '')"/>
+                <attr sel="a" th:text="'«'"
+                      th:class="'page-link' + (${articles.number} <= 0 ? ' disabled' : '')"
+                      th:href="@{/articles(
+                            page=${0},
+                            sort=${param.sort},
+                            searchType=${param.searchType},
+                            searchValue=${param.searchValue}
+                      )}"
+                />
             </attr>
             <attr sel="li[1]" th:class="'page-item' + (${articles.number} <= 0 ? ' disabled' : '')">
-                <attr sel="a" th:text="'‹'" th:href="@{/articles(page=${articles.number - 1})}"
-                      th:class="'page-link' + (${articles.number} <= 0 ? ' disabled' : '')"/>
+                <attr sel="a" th:text="'‹'"
+                      th:class="'page-link' + (${articles.number} <= 0 ? ' disabled' : '')"
+                      th:href="@{/articles(
+                            page=${articles.number - 1},
+                            sort=${param.sort},
+                            searchType=${param.searchType},
+                            searchValue=${param.searchValue}
+                      )}"
+                />
             </attr>
             <attr sel="li[2]" th:each="pageNumber : ${paginationBarNumbers}"
                   th:class="'page-item' + (${articles.number} == ${pageNumber} ? ' active' : '')">
-                <attr sel="a" th:text="${pageNumber + 1}" th:href="@{/articles(page=${pageNumber})}"/>
+                <attr sel="a" th:text="${pageNumber + 1}"
+                      th:href="@{/articles(
+                            page=${pageNumber},
+                            sort=${param.sort},
+                            searchType=${param.searchType},
+                            searchValue=${param.searchValue}
+                      )}"
+                />
             </attr>
             <attr sel="li[3]"
                   th:class="'page-item' + (${articles.number + 1} >= ${articles.totalPages} ? ' disabled' : '')">
-                <attr sel="a" th:text="'›'" th:href="@{/articles(page=${articles.number + 1})}"
-                      th:class="'page-link' + (${articles.number + 1} >= ${articles.totalPages} ? ' disabled' : '')"/>
+                <attr sel="a" th:text="'›'"
+                      th:class="'page-link' + (${articles.number + 1} >= ${articles.totalPages} ? ' disabled' : '')"
+                      th:href="@{/articles(
+                            page=${articles.number + 1},
+                            sort=${param.sort},
+                            searchType=${param.searchType},
+                            searchValue=${param.searchValue}
+                      )}"
+                />
             </attr>
             <attr sel="li[4]"
                   th:class="'page-item' + (${articles.number + 1} >= ${articles.totalPages} ? ' disabled' : '')">
-                <attr sel="a" th:text="'»'" th:href="@{/articles(page=${articles.totalPages - 1})}"
-                      th:class="'page-link' + (${articles.number + 1} >= ${articles.totalPages} ? ' disabled' : '')"/>
+                <attr sel="a" th:text="'»'"
+                      th:class="'page-link' + (${articles.number + 1} >= ${articles.totalPages} ? ' disabled' : '')"
+                      th:href="@{/articles(
+                            page=${articles.totalPages - 1},
+                            sort=${param.sort},
+                            searchType=${param.searchType},
+                            searchValue=${param.searchValue}
+                      )}"
+                />
             </attr>
         </attr>
     </attr>

--- a/src/test/java/com/example/projectboard/controller/ArticleControllerTest.java
+++ b/src/test/java/com/example/projectboard/controller/ArticleControllerTest.java
@@ -9,7 +9,6 @@ import com.example.projectboard.service.PaginationService;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.BDDMockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -20,6 +19,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.*;
@@ -32,7 +32,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Import(SecurityConfig.class)
 @WebMvcTest(ArticleController.class)
 class ArticleControllerTest {
-    
+
     private final MockMvc mvc;
 
     @MockBean
@@ -50,7 +50,7 @@ class ArticleControllerTest {
     @Test
     void givenNothing_whenRequestingArticlesView_thenReturnsArticlesView() throws Exception {
         //given
-        given(articleService.searchArticles(eq(null), eq(null), any(Pageable.class))).willReturn(Page.empty());
+        given(articleService.searchArticles(eq(null), eq(null), eq(null), any(Pageable.class))).willReturn(Page.empty());
         given(paginationService.getPaginationBarNumbers(anyInt(), anyInt())).willReturn(List.of(0, 1, 2, 3, 4));
 
         //when
@@ -62,7 +62,7 @@ class ArticleControllerTest {
                 .andExpect(model().attributeExists("paginationBarNumbers"));
 
         //then
-        then(articleService).should().searchArticles(eq(null), eq(null), any(Pageable.class));
+        then(articleService).should().searchArticles(eq(null), eq(null), eq(null), any(Pageable.class));
         then(paginationService).should().getPaginationBarNumbers(anyInt(), anyInt());
     }
 
@@ -72,7 +72,7 @@ class ArticleControllerTest {
         //given
         SearchType searchType = SearchType.TITLE;
         String searchValue = "title";
-        given(articleService.searchArticles(eq(searchType), eq(searchValue), any(Pageable.class))).willReturn(Page.empty());
+        given(articleService.searchArticles(eq(searchType), eq(searchValue), eq(null), any(Pageable.class))).willReturn(Page.empty());
         given(paginationService.getPaginationBarNumbers(anyInt(), anyInt())).willReturn(List.of(0, 1, 2, 3, 4));
 
         //when
@@ -87,15 +87,33 @@ class ArticleControllerTest {
                 .andExpect(model().attributeExists("searchTypes"));
 
         //then
-        then(articleService).should().searchArticles(eq(searchType), eq(searchValue), any(Pageable.class));
+        then(articleService).should().searchArticles(eq(searchType), eq(searchValue), eq(null), any(Pageable.class));
         then(paginationService).should().getPaginationBarNumbers(anyInt(), anyInt());
     }
 
-    //TODO: 게시판 페이지 pagination, sorting 테스트 코드 작성 (sorting 기능 개발은 다음 이슈때 진행)
+    @DisplayName("[view][GET] 게시판(게시글 리스트) 페이지 - 태그 필터 호출")
+    @Test
+    void givenFilterTags_whenSearchingArticlesView_thenReturnsArticlesView() throws Exception {
+        //given
+        String filterTags = "tag";
+        given(articleService.searchArticles(eq(null), eq(null), eq(List.of(filterTags)), any(Pageable.class))).willReturn(Page.empty());
+        given(paginationService.getPaginationBarNumbers(anyInt(), anyInt())).willReturn(List.of(0, 1, 2, 3, 4));
+
+        //when
+        mvc.perform(get("/articles").queryParam("filterTags", filterTags))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(view().name("articles/index"))
+                .andExpect(model().attributeExists("articles"));
+
+        //then
+        then(articleService).should().searchArticles(eq(null), eq(null), eq(List.of(filterTags)), any(Pageable.class));
+        then(paginationService).should().getPaginationBarNumbers(anyInt(), anyInt());
+    }
 
     @DisplayName("[view][GET] 게시글 상세 페이지 - 정상 호출")
     @Test
-    void viewArticleDetail() throws Exception {
+    void givenArticleId_whenRequestingArticleView_thenReturnsArticleView() throws Exception {
         //given
         Long articleId = 1L;
         given(articleService.getArticle(articleId)).willReturn(createArticleWithCommentDto());
@@ -109,18 +127,6 @@ class ArticleControllerTest {
 
         //then
         then(articleService).should().getArticle(articleId);
-    }
-
-    @Disabled("구현중")
-    @DisplayName("[view][GET] 게시글 해시태그 검색 페이지 - 정상 호출")
-    @Test
-    void viewArticleHashTagSearch() throws Exception {
-        //given
-
-        //when & then
-        mvc.perform(get("/articles/search-hashtag"))
-                .andExpect(status().isOk())
-                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML));
     }
 
     private ArticleWithCommentsDto createArticleWithCommentDto() {

--- a/src/test/java/com/example/projectboard/controller/ArticleControllerTest.java
+++ b/src/test/java/com/example/projectboard/controller/ArticleControllerTest.java
@@ -1,6 +1,7 @@
 package com.example.projectboard.controller;
 
 import com.example.projectboard.config.SecurityConfig;
+import com.example.projectboard.domain.type.SearchType;
 import com.example.projectboard.dto.ArticleWithCommentsDto;
 import com.example.projectboard.dto.MemberDto;
 import com.example.projectboard.service.ArticleService;
@@ -47,7 +48,7 @@ class ArticleControllerTest {
 
     @DisplayName("[view][GET] 게시판(게시글 리스트) 페이지 - 정상 호출")
     @Test
-    void viewArticles() throws Exception {
+    void givenNothing_whenRequestingArticlesView_thenReturnsArticlesView() throws Exception {
         //given
         given(articleService.searchArticles(eq(null), eq(null), any(Pageable.class))).willReturn(Page.empty());
         given(paginationService.getPaginationBarNumbers(anyInt(), anyInt())).willReturn(List.of(0, 1, 2, 3, 4));
@@ -62,6 +63,31 @@ class ArticleControllerTest {
 
         //then
         then(articleService).should().searchArticles(eq(null), eq(null), any(Pageable.class));
+        then(paginationService).should().getPaginationBarNumbers(anyInt(), anyInt());
+    }
+
+    @DisplayName("[view][GET] 게시판(게시글 리스트) 페이지 - 검색어 호출")
+    @Test
+    void givenSearchKeyword_whenSearchingArticlesView_thenReturnsArticlesView() throws Exception {
+        //given
+        SearchType searchType = SearchType.TITLE;
+        String searchValue = "title";
+        given(articleService.searchArticles(eq(searchType), eq(searchValue), any(Pageable.class))).willReturn(Page.empty());
+        given(paginationService.getPaginationBarNumbers(anyInt(), anyInt())).willReturn(List.of(0, 1, 2, 3, 4));
+
+        //when
+        mvc.perform(get("/articles")
+                        .queryParam("searchType", searchType.name())
+                        .queryParam("searchValue", searchValue)
+                )
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(view().name("articles/index"))
+                .andExpect(model().attributeExists("articles"))
+                .andExpect(model().attributeExists("searchTypes"));
+
+        //then
+        then(articleService).should().searchArticles(eq(searchType), eq(searchValue), any(Pageable.class));
         then(paginationService).should().getPaginationBarNumbers(anyInt(), anyInt());
     }
 

--- a/src/test/java/com/example/projectboard/service/ArticleServiceTest.java
+++ b/src/test/java/com/example/projectboard/service/ArticleServiceTest.java
@@ -19,6 +19,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -47,7 +48,7 @@ class ArticleServiceTest {
         given(articleRepository.findAll(pageable)).willReturn(Page.empty());
 
         // When
-        Page<ArticleDto> articles = sut.searchArticles(null, null, pageable);
+        Page<ArticleDto> articles = sut.searchArticles(null, null, null, pageable);
 
         // Then
         assertThat(articles).isEmpty();
@@ -64,26 +65,27 @@ class ArticleServiceTest {
         given(articleRepository.findByTitleContaining(searchKeyword, pageable)).willReturn(Page.empty());
 
         // When
-        Page<ArticleDto> articles = sut.searchArticles(searchType, searchKeyword, pageable);
+        Page<ArticleDto> articles = sut.searchArticles(searchType, searchKeyword, null, pageable);
 
         // Then
         assertThat(articles).isEmpty();
         then(articleRepository).should().findByTitleContaining(searchKeyword, pageable);
     }
 
-    @DisplayName("게시글을 검색하면, 게시글 리스트를 반환한다.")
+    @DisplayName("태그로 필터하면, 게시글 페이지를 반환한다.")
     @Test
-    void givenSearchParams_whenSearchingArticles_thenReturnArticleList() {
-        //given
+    void givenFilterTags_whenSearchingArticles_thenReturnsArticlePage() {
+        // Given
+        List<String> filterTags = List.of("%23blue");
         Pageable pageable = Pageable.ofSize(20);
-        given(articleRepository.findAll(pageable)).willReturn(Page.empty());
+        given(articleRepository.findByHashTagIn(filterTags, pageable)).willReturn(Page.empty());
 
-        //when
-        Page<ArticleDto> articles = sut.searchArticles(null, null, pageable);
+        // When
+        Page<ArticleDto> articles = sut.searchArticles(null, null, filterTags, pageable);
 
-        // then
-        assertThat(articles).isNotNull();
-        then(articleRepository).should().findAll(pageable);
+        // Then
+        assertThat(articles).isEmpty();
+        then(articleRepository).should().findByHashTagIn(filterTags, pageable);
     }
 
     @DisplayName("게시글을 조회하면, 게시글을 반환한다.")

--- a/src/test/java/com/example/projectboard/service/PaginationServiceTest.java
+++ b/src/test/java/com/example/projectboard/service/PaginationServiceTest.java
@@ -46,8 +46,8 @@ class PaginationServiceTest {
                 arguments(2, 7, List.of(0, 1, 2, 3, 4)),
                 arguments(3, 7, List.of(1, 2, 3, 4, 5)),
                 arguments(4, 7, List.of(2, 3, 4, 5, 6)),
-                arguments(5, 7, List.of(3, 4, 5, 6)),
-                arguments(6, 7, List.of(4, 5, 6))
+                arguments(5, 7, List.of(2, 3, 4, 5, 6)),
+                arguments(6, 7, List.of(2, 3, 4, 5, 6))
         );
     }
 


### PR DESCRIPTION
게시판 페이지에서 게시글을 검색하는 기능을 구현했다.

- 검색어 타입과 검색어를 입력해 게시글을 검색할 수 있는 하단 검색바 기능을 개발했다.

- 해시태그 검색은 하단 검색바에 넣을까하다가, 개인적으로 필터링할 수 있는 기능이 있으면 좋겠다고 생각해서 게시판 화면 좌측에 해시태그 목록을 보여주고, 필터링 해서 볼 수 있게 기능을 구현했다.

- 검색바와 해시태그 필터링 기능을 중복해서 게시물을 검색할 수 있도록 처리했다.

This closes #32 