### PR TITLE
헤로쿠 배포 - DB 변경 (ClearDB -> JawsDB)

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -46,7 +46,7 @@ spring:
     activate:
       on-profile: heroku
   datasource:
-    url: ${CLEARDB_DATABASE_URL}
+    url: ${JAWSDB_URL}
   jpa:
     hibernate:
       ddl-auto: create


### PR DESCRIPTION
조사해 본 결과 clearDB 의 MySQL 버전이 너무 낮아서 오류가 발생한 것으로 파악했으며, jawsDB 로 변경
yaml 파일의 환경변수 작업을 다시 함

This fixes #50 