### PR TITLE
[고도화] heroku db 옵션 변경

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -49,8 +49,8 @@ spring:
     url: ${JAWSDB_URL}
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
   sql:
     init:
-      mode: never
+      mode: always
 


### PR DESCRIPTION
#54 에서 init 옵션 수정했으나, 해당 옵션으로 기본 정보(사용자)가 세팅되지 않아 아무 작업도 할 수 없었음

init 옵션은 그대로 두고, hibernate.ddl-auto 옵션을 수정

This fixes #54  