### PR TITLE
[고도화] heroku db 옵션 변경

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -49,7 +49,7 @@ spring:
     url: ${JAWSDB_URL}
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: create
   sql:
     init:
       mode: always

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -49,8 +49,8 @@ spring:
     url: ${JAWSDB_URL}
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
   sql:
     init:
-      mode: never
+      mode: always
 


### PR DESCRIPTION
- jpa.hibernate.ddl-auto 값을 `none` 으로 셋팅했더니, sql.init.mode 값인 `always` 때문에 heroku 서버가 슬립에서 깨어날 때 pk duplicated 오류가 발생해서 원복

- 현재 회원가입 기능이 없으니, 추후 OAuth 기능을 추가하고 heroku db init 옵션 비활성화 하기로 결정

This closes #56 