### PR TITLE
[고도화] 해시태그 기능 고도화

### DIFF
--- a/src/main/java/com/example/projectboard/service/HashtagService.java
+++ b/src/main/java/com/example/projectboard/service/HashtagService.java
@@ -7,8 +7,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -18,19 +22,40 @@ public class HashtagService {
 
     private final HashtagRepository hashtagRepository;
 
-    public Object parseHashtagNames(String content) {
-        return null;
+    public Set<String> parseHashtagNames(String content) {
+        if (content == null) {
+            return Set.of();
+        }
+
+        Pattern pattern = Pattern.compile("#[\\wㄱ-ㅎ가-힣]+");
+        Matcher matcher = pattern.matcher(content.strip());
+        Set<String> result = new HashSet<>();
+
+        while (matcher.find()) {
+            result.add(matcher.group().replace("#", ""));
+        }
+
+        return Set.copyOf(result);
     }
 
-    public Object findHashtagsByNames(Set<String> expectedHashtagNames) {
-        return null;
+    @Transactional(readOnly = true)
+    public Set<Hashtag> findHashtagsByNames(Set<String> hashtagNames) {
+        return hashtagRepository.findByNameIn(hashtagNames);
+    }
+
+    public void deleteHashtagWithoutArticles(Long hashtagId) {
+        Hashtag hashtag = hashtagRepository.getReferenceById(hashtagId);
+        if (hashtag.getArticles().isEmpty()) {
+            hashtagRepository.delete(hashtag);
+        }
     }
 
     @Transactional(readOnly = true)
     public List<String> getAllHashTagNames() {
-        return hashtagRepository.findAll().stream().map(Hashtag::getName).toList();
-    }
-
-    public void deleteHashtagWithoutArticles(Object any) {
+        //좌측 필터링 목록에서 사전순으로 나오면 깔끔할 것 같아서 정렬된 리스트로 반환
+        return hashtagRepository.findAll().stream()
+                .map(Hashtag::getName)
+                .sorted()
+                .collect(Collectors.toUnmodifiableList());
     }
 }

--- a/src/main/resources/templates/articles/detail.html
+++ b/src/main/resources/templates/articles/detail.html
@@ -26,7 +26,7 @@
                     <p><span id="nick-name" class="nick-name">pyo</span></p>
                     <p><a id="email" class="u-url" rel="me" href="mailto:gipyopark@gmail.com">gipyopark@gmail.com</a></p>
                     <p><time id="created-at" datetime="2022-12-22T23:00:00">2022-12-22</time></p>
-                    <p><span id="hash-tag">#spring</span></p>
+                    <p><span id="hash-tag" class="badge text-bg-secondary mx-1"><a class="text-reset">#spring</a></span></p>
                 </aside>
             </section>
 

--- a/src/main/resources/templates/articles/detail.th.xml
+++ b/src/main/resources/templates/articles/detail.th.xml
@@ -6,10 +6,17 @@
     <attr sel="#article-main" th:object="${article}">
         <attr sel="header/h1" th:text="*{title}"/>
         <attr sel="#nick-name" th:text="*{nickname}"/>
-        <attr sel="#email" th:text="*{email}"/>
+        <attr sel="#email" th:href="'mailto:' + *{email}" th:text="*{email}"/>
         <attr sel="#created-at" th:datetime="*{createdAt}"
               th:text="*{#temporals.format(createdAt, 'yyyy-MM-dd HH:mm:ss')}"/>
-        <attr sel="#hash-tag" th:text="*{hashtag}"/>
+        <attr sel="#hash-tag" th:each="hashtag : *{hashtags}">
+            <attr sel="a" th:text="'#' + ${hashtag}"
+                  th:href="@{/articles(
+                              sort=${param.sort},
+                              searchType=${param.searchType},
+                              searchKeyword=${param.searchKeyword},
+                              filterTags=${'{' + hashtag + '}'})}"/>
+        </attr>
         <attr sel="#article-content/pre" th:text="*{content}"/>
     </attr>
 

--- a/src/main/resources/templates/articles/form.html
+++ b/src/main/resources/templates/articles/form.html
@@ -35,12 +35,6 @@
         <textarea class="form-control" id="content" name="content" rows="5" required></textarea>
       </div>
     </div>
-    <div class="row mb-4 justify-content-md-center">
-      <label for="hashtag" class="col-sm-2 col-lg-1 col-form-label text-sm-end">태그</label>
-      <div class="col-sm-8 col-lg-9">
-        <input type="text" class="form-control" id="hashtag" name="hashtag">
-      </div>
-    </div>
     <div class="row mb-5 justify-content-md-center">
       <div class="col-sm-10 d-grid gap-2 d-sm-flex justify-content-sm-end">
         <button type="submit" class="btn btn-primary" id="submit-button">저장</button>

--- a/src/main/resources/templates/articles/index.html
+++ b/src/main/resources/templates/articles/index.html
@@ -28,12 +28,11 @@
                     <div class="grid-body">
                         <div class="row">
                             <!-- BEGIN FILTERS -->
-                            <div class="col-md-3">
-                                <h2 class="grid-title"><i class="fa fa-filter"></i> Filters</h2>
+                            <div class="col-md-2">
+                                <h2 class="grid-title"><i class="fa fa-filter"></i> Filter</h2>
                                 <hr>
 
                                 <!-- BEGIN FILTER BY HASHTAG -->
-                                <h4>By tag:</h4>
                                 <div class="checkbox" id="hash-tag">
                                     <input type="checkbox" class="icheck" />
                                 </div>
@@ -41,9 +40,9 @@
                             </div>
                             <!-- END FILTERS -->
                             <!-- BEGIN RESULT -->
-                            <div class="col-md-9">
+                            <div class="col-md-10">
                                 <h2>
-                                    <i class="fa fa-file-o"></i> Articles
+                                    <i class="fa fa-file-o"></i>
                                     <button id="new-article" class="btn btn-dark float-end" type="button">글쓰기</button>
                                 </h2>
                                 <hr>
@@ -55,7 +54,7 @@
                                         <thead>
                                         <tr>
                                             <th class="title col-6">제목</th>
-                                            <th class="hash-tag col">태그</th>
+                                            <th class="hash-tag col">해시태그</th>
                                             <th class="nick-name col">작성자</th>
                                             <th class="created-at col">작성일</th>
                                         </tr>
@@ -63,7 +62,11 @@
                                         <tbody>
                                         <tr>
                                             <td class="title col-6 text-truncate" style="max-width: 400px">첫 번째 글</td>
-                                            <td class="hash-tag col">#spring</td>
+                                            <td class="hash-tag col">
+                                                <span class="badge text-bg-secondary mx-1">
+                                                    <a class="text-reset">#spring</a>
+                                                </span>
+                                            </td>
                                             <td class="nick-name col">pyo</td>
                                             <td class="created-at col">2022-12-22</td>
                                         </tr>

--- a/src/main/resources/templates/articles/index.th.xml
+++ b/src/main/resources/templates/articles/index.th.xml
@@ -6,13 +6,13 @@
     <attr sel="#new-article" sec:authorize="isAuthenticated()" th:onclick="|location.href='/articles/form'|"/>
 
     <attr sel="#hash-tag" th:each="hashtag : ${hashtags}">
-        <attr sel="input" th:text="' ' + ${hashtag}" th:value="${hashtag}"
-              th:checked="${param.filterTags == null ? 'false' : #strings.contains(param.filterTags, '' + hashtag)}"
+        <attr sel="input" th:text="' #' + ${hashtag}" th:value="${hashtag}"
+              th:checked="${param.filterTags == null ? 'false' : #strings.contains(param.filterTags, '{' + hashtag + '}')}"
               th:onclick="|location.href='@{/articles(
                   sort=${param.sort},
                   searchType=${param.searchType},
                   searchKeyword=${param.searchKeyword},
-                  filterTags=${param.filterTags == null ? '' + hashtag : #strings.contains(param.filterTags, '' + hashtag) ? #strings.replace(param.filterTags, ',' + hashtag, '').replace('' + hashtag, '') : #strings.append(param.filterTags, (#strings.isEmpty(param.filterTags) ? '' : ',') + hashtag)}
+                  filterTags=${param.filterTags == null ? '{' + hashtag + '}' : #strings.contains(param.filterTags, '{' + hashtag + '}') ? #strings.replace(param.filterTags, ',{' + hashtag + '}', '').replace('{' + hashtag + '}', '') : #strings.append(param.filterTags, (#strings.isEmpty(param.filterTags) ? '' : ',') + '{' + hashtag + '}')}
               )}'|"/>
     </attr>
 
@@ -26,14 +26,14 @@
                       searchKeyword=${param.searchKeyword},
                       filterTags=${param.filterTags}
                   )}'|"/>
-            <attr sel="th.hash-tag" th:text="'태그'"
+            <attr sel="th.hash-tag" th:text="'해시태그'"
                   th:onclick="|location.href='@{/articles(
                       page=${articles.number},
-                      sort='hashTag' + (${articles.sort.getOrderFor('hashTag')} != null ? (${articles.sort.getOrderFor('hashTag').direction.name} != 'DESC' ? ',desc' : '') : ''),
+                      sort='hashtags.name' + (${articles.sort.getOrderFor('hashtags.name')} != null ? (${articles.sort.getOrderFor('hashtags.name').direction.name} != 'DESC' ? ',desc' : '') : ''),
                       searchType=${param.searchType},
                       searchKeyword=${param.searchKeyword},
                       filterTags=${param.filterTags}
-                  )}'|"/>
+                  )}'|"/>그
             <attr sel="th.nick-name" th:text="'작성자'"
                   th:onclick="|location.href='@{/articles(
                       page=${articles.number},
@@ -56,7 +56,14 @@
             <attr sel="tr[0]" th:each="article : ${articles}"
                   th:onclick="|location.href='@{'/articles/' + ${article.id}}'|">
                 <attr sel="td.title" th:text="${article.title}"/>
-                <attr sel="td.hash-tag" th:text="${article.hashtags}"/>
+                <attr sel="td.hash-tag/span" th:each="hashtag : ${article.hashtags}">
+                    <attr sel="a" th:text="'#' + ${hashtag}"
+                          th:href="@{/articles(
+                              sort=${param.sort},
+                              searchType=${param.searchType},
+                              searchKeyword=${param.searchKeyword},
+                              filterTags=${'{' + hashtag + '}'})}"/>
+                </attr>
                 <attr sel="td.nick-name" th:text="${article.nickname}"/>
                 <attr sel="td.created-at" th:text="${#temporals.format(article.createdAt, 'yyyy-MM-dd')}"/>
             </attr>

--- a/src/main/resources/templates/footer.html
+++ b/src/main/resources/templates/footer.html
@@ -6,7 +6,7 @@
 </head>
 <body>
 <footer class="container d-flex flex-wrap justify-content-between align-items-center py-3 my-4 border-top">
-    <p class="col-md-4 mb-0 text-muted">&copy; 2022 PARK GI-PYO</p>
+    <p class="col-md-4 mb-0 text-muted">&copy; 2023 PARK GI-PYO</p>
 
     <a href="/"
        class="col-md-4 d-flex align-items-center justify-content-center mb-3 mb-md-0 me-md-auto link-dark text-decoration-none">

--- a/src/main/resources/templates/header.html
+++ b/src/main/resources/templates/header.html
@@ -14,10 +14,10 @@
 
             <div class="text-end">
                 <span id="userinfo" class="text-white me-2">
-                    로그인 : <span id="userid" class="text-white me-2">userid</span>
+                     <span id="userid" class="text-white me-2">userid</span>
                 </span>
-                <a role="button" id="login" class="btn btn-outline-light me-2">Login</a>
-                <a role="button" id="logout" class="btn btn-warning">Logout</a>
+                <a role="button" id="login" class="btn btn-outline-light me-2">로그인</a>
+                <a role="button" id="logout" class="btn btn-warning">로그아웃</a>
             </div>
         </div>
     </div>

--- a/src/test/java/com/example/projectboard/service/ArticleServiceTest.java
+++ b/src/test/java/com/example/projectboard/service/ArticleServiceTest.java
@@ -183,12 +183,12 @@ class ArticleServiceTest {
                 .hasFieldOrPropertyWithValue("content", dto.content())
                 .extracting("hashtags", as(InstanceOfAssertFactories.COLLECTION))
                 .hasSize(1)
-                .extracting("hashtagName")
+                .extracting("name")
                 .containsExactly("springboot");
         then(articleRepository).should().getReferenceById(dto.id());
         then(memberRepository).should().getReferenceById(dto.memberDto().userId());
         then(articleRepository).should().flush();
-        then(hashtagService).should(times(1)).deleteHashtagWithoutArticles(any());
+        then(hashtagService).should(times(2)).deleteHashtagWithoutArticles(any());
         then(hashtagService).should().parseHashtagNames(dto.content());
         then(hashtagService).should().findHashtagsByNames(expectedHashtagNames);
     }
@@ -213,13 +213,19 @@ class ArticleServiceTest {
         //given
         Long articleId = 1L;
         String userId = "test";
+        given(articleRepository.getReferenceById(articleId)).willReturn(createArticle());
         willDoNothing().given(articleRepository).deleteByIdAndMember_UserId(articleId, userId);
+        willDoNothing().given(articleRepository).flush();
+        willDoNothing().given(hashtagService).deleteHashtagWithoutArticles(any());
 
         //when
         sut.deleteArticle(articleId, userId);
 
         //then
+        then(articleRepository).should().getReferenceById(articleId);
         then(articleRepository).should().deleteByIdAndMember_UserId(articleId, userId);
+        then(articleRepository).should().flush();
+        then(hashtagService).should(times(2)).deleteHashtagWithoutArticles(any());
     }
 
     private Member createMember() {

--- a/src/test/java/com/example/projectboard/service/HashtagServiceTest.java
+++ b/src/test/java/com/example/projectboard/service/HashtagServiceTest.java
@@ -1,0 +1,106 @@
+package com.example.projectboard.service;
+
+import com.example.projectboard.domain.Hashtag;
+import com.example.projectboard.repository.HashtagRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.BDDMockito.*;
+
+@DisplayName("비즈니스 로직 - 해시태그")
+@ExtendWith(MockitoExtension.class)
+class HashtagServiceTest {
+
+    @InjectMocks
+    private HashtagService sut;
+
+    @Mock
+    private HashtagRepository hashtagRepository;
+
+    @DisplayName("본문을 파싱하면, 해시태그 이름을 중복 없이 반환한다.")
+    @MethodSource
+    @ParameterizedTest(name = "[{index}] \"{0}\" => {1}")
+    void givenContent_whenParsing_thenReturnsUniqueHashtagName(String input, Set<String> expected) {
+        //given
+
+
+        //when
+        Set<String> actual = sut.parseHashtagNames(input);
+
+        //then
+        assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
+        then(hashtagRepository).shouldHaveNoInteractions();
+    }
+    
+    @DisplayName("해시태그 이름들을 입력하면, 저장된 해시태그 중 이름에 매칭하는 것들을 중복 없이 반환한다.")
+    @Test
+    void givenHashtagNames_whenFindingHashtags_thenReturnsHashtagSet() {
+        // Given
+        Set<String> hashtagNames = Set.of("java", "spring", "boots");
+        given(hashtagRepository.findByNameIn(hashtagNames)).willReturn(Set.of(
+                Hashtag.of("java"),
+                Hashtag.of("spring")
+        ));
+
+        // When
+        Set<Hashtag> hashtags = sut.findHashtagsByNames(hashtagNames);
+
+        // Then
+        assertThat(hashtags).hasSize(2);
+        then(hashtagRepository).should().findByNameIn(hashtagNames);
+    }
+
+    static Stream<Arguments> givenContent_whenParsing_thenReturnsUniqueHashtagName() {
+        return Stream.of(
+                arguments(null, Set.of()),
+                arguments("", Set.of()),
+                arguments("   ", Set.of()),
+                arguments("#", Set.of()),
+                arguments("  #", Set.of()),
+                arguments("#   ", Set.of()),
+                arguments("java", Set.of()),
+                arguments("java#", Set.of()),
+                arguments("ja#va", Set.of("va")),
+                arguments("#java", Set.of("java")),
+                arguments("#java_spring", Set.of("java_spring")),
+                arguments("#java-spring", Set.of("java")),
+                arguments("#_java_spring", Set.of("_java_spring")),
+                arguments("#-java-spring", Set.of()),
+                arguments("#_java_spring__", Set.of("_java_spring__")),
+                arguments("#java#spring", Set.of("java", "spring")),
+                arguments("#java #spring", Set.of("java", "spring")),
+                arguments("#java  #spring", Set.of("java", "spring")),
+                arguments("#java   #spring", Set.of("java", "spring")),
+                arguments("#java     #spring", Set.of("java", "spring")),
+                arguments("  #java     #spring ", Set.of("java", "spring")),
+                arguments("   #java     #spring   ", Set.of("java", "spring")),
+                arguments("#java#spring#부트", Set.of("java", "spring", "부트")),
+                arguments("#java #spring#부트", Set.of("java", "spring", "부트")),
+                arguments("#java#spring #부트", Set.of("java", "spring", "부트")),
+                arguments("#java,#spring,#부트", Set.of("java", "spring", "부트")),
+                arguments("#java.#spring;#부트", Set.of("java", "spring", "부트")),
+                arguments("#java|#spring:#부트", Set.of("java", "spring", "부트")),
+                arguments("#java #spring  #부트", Set.of("java", "spring", "부트")),
+                arguments("   #java,? #spring  ...  #부트 ", Set.of("java", "spring", "부트")),
+                arguments("#java#java#spring#부트", Set.of("java", "spring", "부트")),
+                arguments("#java#java#java#spring#부트", Set.of("java", "spring", "부트")),
+                arguments("#java#spring#java#부트#java", Set.of("java", "spring", "부트")),
+                arguments("#java#스프링 아주 긴 글~~~~~~~~~~~~~~~~~~~~~", Set.of("java", "스프링")),
+                arguments("아주 긴 글~~~~~~~~~~~~~~~~~~~~~#java#스프링", Set.of("java", "스프링")),
+                arguments("아주 긴 글~~~~~~#java#스프링~~~~~~~~~~~~~~~", Set.of("java", "스프링")),
+                arguments("아주 긴 글~~~~~~#java~~~~~~~#스프링~~~~~~~~", Set.of("java", "스프링"))
+        );
+    }
+}


### PR DESCRIPTION
해시태그의 관리 포인트가 변경되었다. (`article` -> `hashtag` 엔티티)

기존에는 게시글 작성/수정 시 별도로 해시태그를 입력했지만, 본문에 해시태그를 입력하고 파싱하여 처리하는 것으로 변경했고 그로인한 변경점을 모두 구현하여 고도화했다.

This closes #67 