### PR TITLE
[리팩토링] application.yaml - heroku db 서버 설정 변경

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -63,8 +63,8 @@ spring:
     url: ${JAWSDB_URL}
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
   sql:
     init:
-      mode: always
+      mode: never
 


### PR DESCRIPTION
해당 pr 은 실제 운영서버인 heroku 에서 db 관련 자동화 옵션을 비활성화 하는 작업이다.

heroku 는 실제 운영서버이므로, `ddl-auto` 와 `sql.init` 옵션을 사용하지 않는 것이 바람직하다고 판단해 해당 옵션을 사용하지 않기로 결정했고, 이를 적용했다.

This closes #94 