### PR TITLE
[버그] @SpringBootTest 실패 수정 - 민감정보의 환경변수 적용

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -68,3 +68,13 @@ spring:
     init:
       mode: never
 
+---
+
+spring:
+  config:
+    activate:
+      on-profile: test
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=MySQL;
+    driver-class-name: org.h2.Driver
+    username: sa

--- a/src/test/java/com/example/projectboard/ProjectBoardApplicationTests.java
+++ b/src/test/java/com/example/projectboard/ProjectBoardApplicationTests.java
@@ -2,7 +2,9 @@ package com.example.projectboard;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class ProjectBoardApplicationTests {
 

--- a/src/test/java/com/example/projectboard/util/FormDataEncoderTest.java
+++ b/src/test/java/com/example/projectboard/util/FormDataEncoderTest.java
@@ -6,12 +6,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.math.BigDecimal;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
+@ActiveProfiles("test")
 @DisplayName("테스트 도구 - Form 데이터 인코더")
 @Import({FormDataEncoder.class, ObjectMapper.class})
 @SpringBootTest


### PR DESCRIPTION
해당 pr 은 `application.yaml` 파일의 민감정보에 대한 보안성 향상을 위해 환경변수로 적용했던 부분이 일부 `SpringBootTest` 에서 정상적으로 환경변수를 주입 받지 못해 실패하는 현상이 발견되어 이를 정상적으로 동작할 수 있게 수정하는 작업이다.

This closes #96 